### PR TITLE
make code-lint skill language-agnostic

### DIFF
--- a/plugin/meta/ase-constitution.md
+++ b/plugin/meta/ase-constitution.md
@@ -44,8 +44,12 @@ Commandments
 - Place spaces after opening and before closing angle brackets and braces.
 - Use *double-quotes* (`"[...]"`) instead of single-quotes (`'[...]'`) for all strings.
 - Use K&R coding style with *opening braces* at end of lines and *closing braces* at the begin of lines.
-- When working with TypeScript/JavaScript, prefer *TypeScript* syntax.
-- When generating temporary helper programs, prefer *TypeScript* syntax.
+- When a language has a *more strongly-typed variant*, prefer that
+  variant (e.g., TypeScript over JavaScript, Python with type hints
+  over untyped Python).
+- When generating temporary helper programs, prefer the *target project's
+  primary programming language* (e.g., TypeScript for TS/JS projects,
+  Python for Python projects, Go for Go projects).
 
 Tenets
 ------

--- a/plugin/skills/ase-code-lint/SKILL.md
+++ b/plugin/skills/ase-code-lint/SKILL.md
@@ -74,6 +74,9 @@ related to a set of code quality aspects.
 1.  <step id="Preparation">
     *Find* and *read* all the corresponding source code files
     and all *related* source code files.
+    *Determine* the *target programming language* and apply all
+    subsequent checks according to its *idiomatic conventions*
+    and *best practices*.
     </step>
 
 2.  <step id="A01 - FORMATTING">
@@ -96,9 +99,9 @@ related to a set of code quality aspects.
     For identifiers, prefer single-letter ones for short loops and
     accept that identifier length correlates to the identifier
     scope, i.e., longer identifiers are acceptable for larger
-    scopes. For all indentifers, prefer camel-case. For classes and
-    interfaces, prefer first letter to be upper-case. For parameters
-    and variables, prefer first letter to be lower-case.
+    scopes. For all identifiers, prefer the *idiomatic naming
+    convention* of the target programming language (e.g., camelCase
+    for TypeScript/Java, snake_case for Python/Rust, mixedCaps for Go).
     </expand>
     </step>
 
@@ -149,9 +152,10 @@ related to a set of code quality aspects.
     best practices.
 
     For design patterns, especially check for broken OOP and FP aspects.
-    For conventions, especially check for broken TypeScript/JavaScript
-    conventions. For best practices, especially check for not leveraging
-    ECMAScript APIs or using obsolete ECMAScript APIs.
+    For conventions, especially check for broken *idiomatic conventions
+    of the target programming language*. For best practices, especially
+    check for not leveraging *standard library APIs* or using *obsolete
+    or deprecated APIs*.
     </expand>
     </step>
 
@@ -180,7 +184,8 @@ related to a set of code quality aspects.
     Check for code smells.
 
     Especially, check for unnecessary type casts, problematic value
-    coercions, surprising void() and risky eval() constructs.
+    coercions, and *language-specific anti-patterns* (e.g., void()/eval()
+    in JavaScript, unsafe blocks in Rust, reflect in Go).
     </expand>
     </step>
 
@@ -189,9 +194,11 @@ related to a set of code quality aspects.
     Check for broken "maximum type safety with minimum type
     annotations" rule.
 
-    Especially, ensure that no implicit "any" type exists and that types
-    are primarily used on function parameters. For all other cases,
-    ensure that a maximum type inference is used.
+    Especially, ensure that no *implicit untyped constructs* exist
+    (e.g., implicit "any" in TypeScript, untyped interface{} in Go,
+    missing type hints in Python) and that types are primarily used on
+    function parameters. For all other cases, ensure that a *maximum
+    type inference* is used.
     </expand>
     </step>
 
@@ -200,9 +207,11 @@ related to a set of code quality aspects.
     Check for missing, incorrect or inconsistent error handling or
     error preventions.
 
-    Surround code blocks with try/catch-clauses only if really
-    necessary to not clutter the code too much with error handling. For
-    asynchronous code, prefer .catch() instead of try/catch.
+    Surround code blocks with error handling constructs only if really
+    necessary to not clutter the code too much with error handling.
+    For error handling, prefer the *idiomatic error handling pattern*
+    of the target programming language (e.g., .catch() in JavaScript,
+    Result<T,E> in Rust, if err != nil in Go).
     </expand>
     </step>
 
@@ -222,7 +231,9 @@ related to a set of code quality aspects.
     Check for concurrency or parallelism race conditions.
 
     Especially, check for potential problems of code which runs
-    asynchronously from timeout/interval or I/O driven callbacks.
+    *concurrently or asynchronously* through the target language's
+    *concurrency model* (e.g., event-loop callbacks in JavaScript,
+    goroutines in Go, threads in Java/C++, async/await in Rust/Python).
     </expand>
     </step>
 


### PR DESCRIPTION
## Summary

- Replace hardcoded *TypeScript/JavaScript/ECMAScript* references in `plugin/skills/ase-code-lint/SKILL.md` with generic formulations plus concrete language examples, so the linter works correctly across Python, Go, Rust, Java, C/C++ etc. without losing JS/TS functionality.
- Generalize the two TypeScript-specific rules in `plugin/meta/ase-constitution.md` into language-neutral principles: prefer strongly-typed language variants where available, and match the target project's primary language for helper programs.

## Motivation

The `ase-code-lint` skill hardcoded JS/TS idioms into 6 of 20 lint aspects (A02 naming, A07 patterns, A10 smells, A11 typing, A12 error-handling, A14 concurrency). On non-JS/TS code this produced false positives (e.g., camelCase complaints on Python) and missed real issues (e.g., no `Result<T,E>` check for Rust). The constitution's unconditional "prefer TypeScript syntax" rule similarly pushed TS even into non-TS contexts.

## Approach

Minimal-invasive rewrites following a consistent pattern: generic instruction + parenthesized language examples as orientation for the LLM. No new detection step, no lookup tables — just clearer prompts.

## Changes

- `plugin/skills/ase-code-lint/SKILL.md`: Preparation step now asks the LLM to determine the target language; A02/A07/A10/A11/A12/A14 use generic formulations with language examples.
- `plugin/meta/ase-constitution.md`: Two TS-specific rules replaced by language-neutral principles with examples.

## Test plan

- [ ] Run `/ase:ase-code-lint` on a TypeScript file → same behavior as before for TS idioms
- [ ] Run `/ase:ase-code-lint` on a Python file → snake_case accepted, type hints checked, no camelCase complaints
- [ ] Run `/ase:ase-code-lint` on a Go file → mixedCaps accepted, `if err != nil` checked, no `.catch()` suggestions
- [ ] Verify AGENTS.md and README.md language references remain intact (these are legitimately descriptive of the ASE tool itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)