### PR TITLE
Render diagrams deterministically via ase diagram subcommand

### DIFF
--- a/plugin/meta/ase-skill.md
+++ b/plugin/meta/ase-skill.md
@@ -23,6 +23,17 @@ Skill Output
 
 -   *IMPORTANT*: For *Diagrams*:
 
+    -   For *complex* diagrams (≥2 nesting levels, ≥4 siblings in
+        a single row, multi-edge fan-out, or any Sequence, State,
+        or Class diagram) you *MUST* emit the diagram as Mermaid
+        source and invoke the `Bash` tool with `ase diagram`
+        piping the Mermaid source on stdin, then include the
+        tool's stdout *verbatim* inside a Markdown fenced code
+        block. The tool defaults to aligned Unicode box-drawing;
+        do *not* pass `--ascii`. Do *not* hand-draw these. For
+        *simple* diagrams (≤3 boxes, linear flow, no nesting, no
+        sibling rows) the hand-drawing rules below still apply.
+
     -   Use *monospace-safe characters only*. *Prefer Unicode* box-drawing
         (angular corners: `┌┐└┘`, rounded corners: `╭╮╰╯`, lines:
         `│├┤─┬┴┼╌┄┈⋯`), arrows (arrowheads: `▷◁▽△▶◀▼▲`, small arrows:
@@ -31,18 +42,20 @@ Skill Output
         (`/`, `\`) and double-width glyphs (emoji, CJK), as both break
         alignment.
 
-    -   *Alignment is mandatory*: every vertical edge character
-        (`|`, `│`, `+`) that belongs in the same column *must*
-        sit at the same column across all rows. Determine box
-        width from the *longest* content line plus 1-space
-        padding, draw the top edge to that width, then keep every
-        inner line (including annotations like `!`, `?`, `*`)
-        within it. Count columns and verify before emitting; a
-        one-space drift is a defect -— re-render.
+    -   *Alignment is mandatory* for hand-drawn simple diagrams:
+        every vertical edge character (`|`, `│`, `+`) that belongs
+        in the same column *must* sit at the same column across
+        all rows. Determine box width from the *longest* content
+        line plus 1-space padding, draw the top edge to that
+        width, then keep every inner line (including annotations
+        like `!`, `?`, `*`) within it. Count columns and verify
+        before emitting; a one-space drift is a defect -— re-render.
 
-    -   *Always* ensure diagrams are *concise* and *compact* by keeping
-        them below 120 characters in total width and below 80 lines in total
-        height.
+    -   *Always* ensure hand-drawn diagrams are *concise* and
+        *compact* by keeping them below 120 characters in total
+        width and below 80 lines in total height. If either
+        budget would be exceeded, the diagram is *complex* and
+        must be rendered via `ase diagram` instead.
 
     -   For diagrams prefer the following diagrams types: for
         *structure* (layout, components, dependencies, etc) use

--- a/plugin/meta/ase-skill.md
+++ b/plugin/meta/ase-skill.md
@@ -36,14 +36,25 @@ Skill Output
     -   *Keep diagrams narrow* — target *≤120 chars rendered
         width*. The renderer's horizontal extent scales with
         siblings per row, node label lengths, and inter-node
-        padding. Prefer `flowchart TB` (top-to-bottom) over `LR`;
-        limit *siblings per row* to *≤4* and group further items
-        into nested `subgraph` hierarchies; keep *node labels*
-        *≤30 chars* (abbreviate long names, drop adjectives). If
-        the rendered output still exceeds the budget, restructure
-        the Mermaid source — do *not* widen the terminal and do
-        *not* raise `--pad-x`/`--pad-y` (defaults `3`/`3` are
-        already tight; lower values break junction rendering).
+        padding. *Always* use `flowchart TB` (top-to-bottom) —
+        never `LR`, `RL`, or `BT` (portrait beats landscape for
+        terminals and code review diffs). Limit *siblings per
+        row* to *≤4* and group further items into nested
+        `subgraph` hierarchies; keep *node labels* *≤30 chars*
+        (abbreviate long names, drop adjectives). If the rendered
+        output still exceeds the budget, restructure the Mermaid
+        source — do *not* widen the terminal and do *not* raise
+        `--pad-x`/`--pad-y` (defaults `3`/`3` are already tight;
+        lower values break junction rendering).
+
+    -   *Keep edges inside subgraph boundaries*. An edge that
+        crosses a `subgraph` border produces a visually ambiguous
+        `┼` glyph where the border line (`─`) and the edge line
+        (`─`) collide — the box appears to merge into the arrow.
+        If a node has edges to peers *outside* a subgraph, either
+        move the node out of the subgraph or widen the subgraph
+        to include both endpoints. Never let arrows pierce
+        `subgraph` walls.
 
     -   For diagrams prefer the following diagrams types: for
         *structure* (layout, components, dependencies, etc) use

--- a/plugin/meta/ase-skill.md
+++ b/plugin/meta/ase-skill.md
@@ -23,15 +23,29 @@ Skill Output
 
 -   *IMPORTANT*: For *Diagrams*:
 
-    -   You *MUST* emit *every* diagram as Mermaid source and
-        invoke the `Bash` tool with `ase diagram` piping the
-        Mermaid source on stdin, then include the tool's stdout
-        *verbatim* inside a Markdown fenced code block. The tool
-        defaults to aligned Unicode box-drawing; do *not* pass
-        `--ascii`. Do *not* hand-draw diagrams -— token-by-token
+    -   *NEVER hand-draw diagrams under any circumstances*.
+        Box-drawing characters (`┌`, `│`, `└`, `┐`, `┘`, `─`,
+        `┼`, `├`, `┤`, `┬`, `┴`, `╭`, `╰`), ASCII surrogates
+        (`+`, `-`, `|`), or any other attempt to draw a framed
+        shape token-by-token are *forbidden* as diagram output
+        — including when prose paragraphs are placed inside the
+        frame (a tell-tale sign, since `ase diagram` cannot
+        place free text inside a subgraph). Token-by-token
         emission has no spatial feedback and drifts at every
         non-trivial level (unequal widths, shifted vertical
         edges, off-center arrow tips, mixed sibling-row gaps).
+
+    -   *MUST use `ase diagram`*. Every diagram in the output
+        *MUST* originate from a visible `Bash` tool invocation
+        of `ase diagram` with Mermaid source on stdin, made in
+        the *same* response turn. The visible tool call is the
+        proof. *Self-check before emitting*: if your response
+        contains any of the box-drawing characters listed above
+        *without* a preceding `Bash(ase diagram ...)` tool call
+        in this same turn, you broke the rule — re-render via
+        the tool. The tool's stdout is included *verbatim*
+        inside a Markdown fenced code block. The tool defaults
+        to aligned Unicode box-drawing; do *not* pass `--ascii`.
 
     -   *Keep diagrams narrow* — target *≤120 chars rendered
         width*. The renderer's horizontal extent scales with

--- a/plugin/meta/ase-skill.md
+++ b/plugin/meta/ase-skill.md
@@ -69,6 +69,15 @@ Skill Output
     -   *Always* render diagrams inside a Markdown *fenced code block*
         (triple backticks).
 
+    -   For *comparison diagrams* (e.g., *current vs. proposed*,
+        *before vs. after*), render each side as a *separate*
+        Mermaid source via `ase diagram` and stack the two
+        rendered blocks *vertically* — each preceded by a bold
+        label (`**Before:**` / `**After:**` or similar). Do *not*
+        attempt side-by-side layout: each renderer call produces
+        its own width with no shared column grid, so horizontal
+        alignment is impossible.
+
 -   *IMPORTANT*: For Markdown *Tables*:
 
     -   *Alignment is mandatory*: every vertical edge character

--- a/plugin/meta/ase-skill.md
+++ b/plugin/meta/ase-skill.md
@@ -56,13 +56,15 @@ Skill Output
         to include both endpoints. Never let arrows pierce
         `subgraph` walls.
 
-    -   For diagrams prefer the following diagrams types: for
-        *structure* (layout, components, dependencies, etc) use
-        Boxes'n'Lines, for *control flow* (branching, concurrency, etc)
-        use Flowchart, for *state machine* (states, transitions, etc) use
-        UML State Diagram, for *data flow* (actors, messages, etc) use UML
-        Sequence Diagram, and for *data structure* (classes, entities,
-        relationships, etc) use UML Class Diagram.
+    -   For diagrams, choose the Mermaid type per intent:
+
+        -   *structure / layout / components / dependencies* → `flowchart TB`
+        -   *control flow / branching / concurrency*         → `flowchart TB`
+        -   *state machine / states / transitions*           → `stateDiagram-v2`
+        -   *data flow / actors / messages / protocols*      → `sequenceDiagram`
+        -   *data structure / classes / methods*             → `classDiagram`
+        -   *data model / entities / relationships*          → `erDiagram`
+        -   *metrics / distributions / time series*          → `xychart-beta`
 
     -   *Always* render diagrams inside a Markdown *fenced code block*
         (triple backticks).

--- a/plugin/meta/ase-skill.md
+++ b/plugin/meta/ase-skill.md
@@ -23,39 +23,15 @@ Skill Output
 
 -   *IMPORTANT*: For *Diagrams*:
 
-    -   For *complex* diagrams (≥2 nesting levels, ≥4 siblings in
-        a single row, multi-edge fan-out, or any Sequence, State,
-        or Class diagram) you *MUST* emit the diagram as Mermaid
-        source and invoke the `Bash` tool with `ase diagram`
-        piping the Mermaid source on stdin, then include the
-        tool's stdout *verbatim* inside a Markdown fenced code
-        block. The tool defaults to aligned Unicode box-drawing;
-        do *not* pass `--ascii`. Do *not* hand-draw these. For
-        *simple* diagrams (≤3 boxes, linear flow, no nesting, no
-        sibling rows) the hand-drawing rules below still apply.
-
-    -   Use *monospace-safe characters only*. *Prefer Unicode* box-drawing
-        (angular corners: `┌┐└┘`, rounded corners: `╭╮╰╯`, lines:
-        `│├┤─┬┴┼╌┄┈⋯`), arrows (arrowheads: `▷◁▽△▶◀▼▲`, small arrows:
-        `→←↑↓`), connectors (`◌○◎◉●■□◆◇`), and regions (`░▒▓█`) over
-        plain ASCII (`+-|<>^v`). Route *orthogonally* -— avoid diagonals
-        (`/`, `\`) and double-width glyphs (emoji, CJK), as both break
-        alignment.
-
-    -   *Alignment is mandatory* for hand-drawn simple diagrams:
-        every vertical edge character (`|`, `│`, `+`) that belongs
-        in the same column *must* sit at the same column across
-        all rows. Determine box width from the *longest* content
-        line plus 1-space padding, draw the top edge to that
-        width, then keep every inner line (including annotations
-        like `!`, `?`, `*`) within it. Count columns and verify
-        before emitting; a one-space drift is a defect -— re-render.
-
-    -   *Always* ensure hand-drawn diagrams are *concise* and
-        *compact* by keeping them below 120 characters in total
-        width and below 80 lines in total height. If either
-        budget would be exceeded, the diagram is *complex* and
-        must be rendered via `ase diagram` instead.
+    -   You *MUST* emit *every* diagram as Mermaid source and
+        invoke the `Bash` tool with `ase diagram` piping the
+        Mermaid source on stdin, then include the tool's stdout
+        *verbatim* inside a Markdown fenced code block. The tool
+        defaults to aligned Unicode box-drawing; do *not* pass
+        `--ascii`. Do *not* hand-draw diagrams -— token-by-token
+        emission has no spatial feedback and drifts at every
+        non-trivial level (unequal widths, shifted vertical
+        edges, off-center arrow tips, mixed sibling-row gaps).
 
     -   For diagrams prefer the following diagrams types: for
         *structure* (layout, components, dependencies, etc) use
@@ -64,10 +40,6 @@ Skill Output
         UML State Diagram, for *data flow* (actors, messages, etc) use UML
         Sequence Diagram, and for *data structure* (classes, entities,
         relationships, etc) use UML Class Diagram.
-
-    -   For side-by-side diagrams (current vs. proposed), keep a
-        consistent gap, use `vs.` in between, and align each side
-        independently.
 
     -   *Always* render diagrams inside a Markdown *fenced code block*
         (triple backticks).

--- a/plugin/meta/ase-skill.md
+++ b/plugin/meta/ase-skill.md
@@ -21,99 +21,13 @@ Skill Output
 
 -   *IMPORTANT*: You *MUST* *NEVER* output any `---` lines.
 
--   *IMPORTANT*: For *Diagrams*:
-
-    -   *NEVER hand-draw diagrams under any circumstances*.
-        Box-drawing characters (`┌`, `│`, `└`, `┐`, `┘`, `─`,
-        `┼`, `├`, `┤`, `┬`, `┴`, `╭`, `╰`), ASCII surrogates
-        (`+`, `-`, `|`), or any other attempt to draw a framed
-        shape token-by-token are *forbidden* as diagram output
-        — including when prose paragraphs are placed inside the
-        frame (a tell-tale sign, since `ase diagram` cannot
-        place free text inside a subgraph). Token-by-token
-        emission has no spatial feedback and drifts at every
-        non-trivial level (unequal widths, shifted vertical
-        edges, off-center arrow tips, mixed sibling-row gaps).
-
-    -   *MUST use `ase diagram`*. Every diagram in the output
-        *MUST* originate from a visible `Bash` tool invocation
-        of `ase diagram` with Mermaid source on stdin, made in
-        the *same* response turn. The visible tool call is the
-        proof. *Self-check before emitting*: if your response
-        contains any of the box-drawing characters listed above
-        *without* a preceding `Bash(ase diagram ...)` tool call
-        in this same turn, you broke the rule — re-render via
-        the tool. The tool defaults to aligned Unicode box-
-        drawing; do *not* pass `--ascii`.
-
-    -   *MUST reproduce the tool stdout in the response text*.
-        After the `Bash(ase diagram ...)` call completes, the
-        skill *MUST* copy the tool's stdout *verbatim* into a
-        Markdown fenced code block placed in the response text
-        immediately after the tool call. The terminal's Bash-
-        tool display is *collapsed* by default (`+N lines
-        (ctrl+o to expand)`) — the user reads the fenced block
-        in the response, not the tool display. *Both* must
-        appear. Emitting only the tool call without the
-        reproduction is a defect: the diagram is effectively
-        invisible.
-
-    -   *Keep diagrams narrow* — target *≤120 chars rendered
-        width*. The renderer's horizontal extent scales with
-        siblings per row, node label lengths, and inter-node
-        padding. *Always* use `flowchart TB` (top-to-bottom) —
-        never `LR`, `RL`, or `BT` (portrait beats landscape for
-        terminals and code review diffs). Limit *siblings per
-        row* to *≤4* and group further items into nested
-        `subgraph` hierarchies; keep *node labels* *≤30 chars*
-        (abbreviate long names, drop adjectives). If the rendered
-        output still exceeds the budget, restructure the Mermaid
-        source — do *not* widen the terminal and do *not* raise
-        `--pad-x`/`--pad-y` (defaults `3`/`3` are already tight;
-        lower values break junction rendering).
-
-    -   *Budget compliance is non-negotiable*. If restructuring
-        the Mermaid source cannot bring the rendered width
-        ≤120 chars (e.g., four populated `subgraph`s side by
-        side), *reduce scope*: show only the *top-level
-        structure* (the root node and ≤1 level of children) in
-        the diagram, and enumerate the detail as a bulleted
-        list *below* the rendered block. *Never* emit Mermaid
-        source as a substitute for a rendered diagram. The
-        choice is: render (possibly at reduced scope) or omit
-        the diagram entirely with a one-line note — *not* ship
-        unrendered source.
-
-    -   *Keep edges inside subgraph boundaries*. An edge that
-        crosses a `subgraph` border produces a visually ambiguous
-        `┼` glyph where the border line (`─`) and the edge line
-        (`─`) collide — the box appears to merge into the arrow.
-        If a node has edges to peers *outside* a subgraph, either
-        move the node out of the subgraph or widen the subgraph
-        to include both endpoints. Never let arrows pierce
-        `subgraph` walls.
-
-    -   For diagrams, choose the Mermaid type per intent:
-
-        -   *structure / layout / components / dependencies* → `flowchart TB`
-        -   *control flow / branching / concurrency*         → `flowchart TB`
-        -   *state machine / states / transitions*           → `stateDiagram-v2`
-        -   *data flow / actors / messages / protocols*      → `sequenceDiagram`
-        -   *data structure / classes / methods*             → `classDiagram`
-        -   *data model / entities / relationships*          → `erDiagram`
-        -   *metrics / distributions / time series*          → `xychart-beta`
-
-    -   *Always* render diagrams inside a Markdown *fenced code block*
-        (triple backticks).
-
-    -   For *comparison diagrams* (e.g., *current vs. proposed*,
-        *before vs. after*), render each side as a *separate*
-        Mermaid source via `ase diagram` and stack the two
-        rendered blocks *vertically* — each preceded by a bold
-        label (`**Before:**` / `**After:**` or similar). Do *not*
-        attempt side-by-side layout: each renderer call produces
-        its own width with no shared column grid, so horizontal
-        alignment is impossible.
+-   *IMPORTANT*: For *Diagrams*: whenever the response needs a
+    diagram (structural, control-flow, state, sequence, class,
+    entity-relationship, or metrics), you *MUST* invoke the
+    `ase-diagram` skill via the `Skill` tool and follow its rules.
+    All hand-drawn ASCII frames, raw Mermaid source as a
+    substitute for a rendered block, and missing stdout
+    reproduction are defects defined by that skill.
 
 -   *IMPORTANT*: For Markdown *Tables*:
 

--- a/plugin/meta/ase-skill.md
+++ b/plugin/meta/ase-skill.md
@@ -33,6 +33,18 @@ Skill Output
         non-trivial level (unequal widths, shifted vertical
         edges, off-center arrow tips, mixed sibling-row gaps).
 
+    -   *Keep diagrams narrow* — target *≤120 chars rendered
+        width*. The renderer's horizontal extent scales with
+        siblings per row, node label lengths, and inter-node
+        padding. Prefer `flowchart TB` (top-to-bottom) over `LR`;
+        limit *siblings per row* to *≤4* and group further items
+        into nested `subgraph` hierarchies; keep *node labels*
+        *≤30 chars* (abbreviate long names, drop adjectives). If
+        the rendered output still exceeds the budget, restructure
+        the Mermaid source — do *not* widen the terminal and do
+        *not* raise `--pad-x`/`--pad-y` (defaults `3`/`3` are
+        already tight; lower values break junction rendering).
+
     -   For diagrams prefer the following diagrams types: for
         *structure* (layout, components, dependencies, etc) use
         Boxes'n'Lines, for *control flow* (branching, concurrency, etc)

--- a/plugin/meta/ase-skill.md
+++ b/plugin/meta/ase-skill.md
@@ -47,6 +47,18 @@ Skill Output
         `--pad-x`/`--pad-y` (defaults `3`/`3` are already tight;
         lower values break junction rendering).
 
+    -   *Budget compliance is non-negotiable*. If restructuring
+        the Mermaid source cannot bring the rendered width
+        ≤120 chars (e.g., four populated `subgraph`s side by
+        side), *reduce scope*: show only the *top-level
+        structure* (the root node and ≤1 level of children) in
+        the diagram, and enumerate the detail as a bulleted
+        list *below* the rendered block. *Never* emit Mermaid
+        source as a substitute for a rendered diagram. The
+        choice is: render (possibly at reduced scope) or omit
+        the diagram entirely with a one-line note — *not* ship
+        unrendered source.
+
     -   *Keep edges inside subgraph boundaries*. An edge that
         crosses a `subgraph` border produces a visually ambiguous
         `┼` glyph where the border line (`─`) and the edge line

--- a/plugin/meta/ase-skill.md
+++ b/plugin/meta/ase-skill.md
@@ -43,9 +43,20 @@ Skill Output
         contains any of the box-drawing characters listed above
         *without* a preceding `Bash(ase diagram ...)` tool call
         in this same turn, you broke the rule — re-render via
-        the tool. The tool's stdout is included *verbatim*
-        inside a Markdown fenced code block. The tool defaults
-        to aligned Unicode box-drawing; do *not* pass `--ascii`.
+        the tool. The tool defaults to aligned Unicode box-
+        drawing; do *not* pass `--ascii`.
+
+    -   *MUST reproduce the tool stdout in the response text*.
+        After the `Bash(ase diagram ...)` call completes, the
+        skill *MUST* copy the tool's stdout *verbatim* into a
+        Markdown fenced code block placed in the response text
+        immediately after the tool call. The terminal's Bash-
+        tool display is *collapsed* by default (`+N lines
+        (ctrl+o to expand)`) — the user reads the fenced block
+        in the response, not the tool display. *Both* must
+        appear. Emitting only the tool call without the
+        reproduction is a defect: the diagram is effectively
+        invisible.
 
     -   *Keep diagrams narrow* — target *≤120 chars rendered
         width*. The renderer's horizontal extent scales with

--- a/plugin/settings.json
+++ b/plugin/settings.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "Bash(ase diagram:*)"
+      "Bash(ase diagram:*)",
+      "Skill(ase:ase-diagram)"
     ]
   }
 }

--- a/plugin/settings.json
+++ b/plugin/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ase diagram:*)"
+    ]
+  }
+}

--- a/plugin/skills/ase-code-elaborate/SKILL.md
+++ b/plugin/skills/ase-code-elaborate/SKILL.md
@@ -50,7 +50,8 @@ specialized in *debugging and fixing source code*.
      (branching, concurrency, etc), complex *state machine* (states,
      transitions, etc), complex *data flow* (actors, messages, etc), or
      complex *data structure* (classes, entities, relationships, etc),
-     visualize it with an optional diagram <optional-diagram/>. Omit
+     visualize it with an optional diagram <optional-diagram/> by
+     invoking the `ase-diagram` skill via the `Skill` tool. Omit
      <optional-diagram/> entirely for simple or purely local situation.
    </step>
 
@@ -86,9 +87,13 @@ specialized in *debugging and fixing source code*.
      avoid cluttering the source code with too much error handling at all.
 
    - In case of a *complex solution situation* only, visualize it with
-     an optional diagram <optional-diagram/>, showing a *side-by-side
-     diagram (current vs. proposed)* Omit <optional-diagram/> entirely
-     for simple or purely local situation.
+     an optional diagram <optional-diagram/> by invoking the
+     `ase-diagram` skill via the `Skill` tool. For *current vs.
+     proposed* comparisons, render each side as a *separate*
+     `ase-diagram` invocation and stack the rendered blocks
+     *vertically* (labels `**Before:**` / `**After:**`); never
+     side-by-side. Omit <optional-diagram/> entirely for simple or
+     purely local situation.
    </step>
 
 3. <step id="STEP 3: Choose Solution Approach">

--- a/plugin/skills/ase-code-explain/SKILL.md
+++ b/plugin/skills/ase-code-explain/SKILL.md
@@ -60,14 +60,14 @@ code and *explain* it in *brief*, *standardized*, and *concise* way.
     style of explanations. For very complex concepts, use multiple
     analogies.
 
-    Second, draw a diagram as ASCII art (with Unicode symbols) to show
-    the control or data flow, code or data structure, or code or data
-    relationships. What gives the best overall overview of the code?
-    Choose the best diagrams of the types UML Class Diagram, UML State
-    Diagram, UML Sequence Diagram, or Boxes'n'Lines.
-    Render the diagram via `ase diagram` by piping Mermaid source
-    through the `Bash` tool, per the *Diagrams* rules in the skill
-    meta. Do *not* hand-draw.
+    Second, draw a diagram to show the control or data flow, code or
+    data structure, or code or data relationships. What gives the best
+    overall overview of the code?
+    Choose the Mermaid diagram type per intent: `classDiagram` for
+    class/method structure, `sequenceDiagram` for actor/message flow,
+    or `flowchart TB` for boxes-and-lines component layouts.
+    Invoke the `ase-diagram` skill via the `Skill` tool to render the
+    diagram. Do *not* hand-draw.
 
     Keep your explanation *brief* and *concise*.
     Output the result with the following <template/>:

--- a/plugin/skills/ase-code-explain/SKILL.md
+++ b/plugin/skills/ase-code-explain/SKILL.md
@@ -65,6 +65,10 @@ code and *explain* it in *brief*, *standardized*, and *concise* way.
     relationships. What gives the best overall overview of the code?
     Choose the best diagrams of the types UML Class Diagram, UML State
     Diagram, UML Sequence Diagram, or Boxes'n'Lines.
+    For any *complex* diagram (nesting, ≥4 siblings in a row, Sequence,
+    State, or Class diagrams) render via `ase diagram` by piping
+    Mermaid source through the `Bash` tool, per the *Diagrams* rules
+    in the skill meta. Only ≤3-box linear sketches may be hand-drawn.
 
     Keep your explanation *brief* and *concise*.
     Output the result with the following <template/>:

--- a/plugin/skills/ase-code-explain/SKILL.md
+++ b/plugin/skills/ase-code-explain/SKILL.md
@@ -65,10 +65,9 @@ code and *explain* it in *brief*, *standardized*, and *concise* way.
     relationships. What gives the best overall overview of the code?
     Choose the best diagrams of the types UML Class Diagram, UML State
     Diagram, UML Sequence Diagram, or Boxes'n'Lines.
-    For any *complex* diagram (nesting, ≥4 siblings in a row, Sequence,
-    State, or Class diagrams) render via `ase diagram` by piping
-    Mermaid source through the `Bash` tool, per the *Diagrams* rules
-    in the skill meta. Only ≤3-box linear sketches may be hand-drawn.
+    Render the diagram via `ase diagram` by piping Mermaid source
+    through the `Bash` tool, per the *Diagrams* rules in the skill
+    meta. Do *not* hand-draw.
 
     Keep your explanation *brief* and *concise*.
     Output the result with the following <template/>:

--- a/plugin/skills/ase-code-insight/SKILL.md
+++ b/plugin/skills/ase-code-insight/SKILL.md
@@ -83,9 +83,10 @@ Give *insights* into the project through the source code of $ARGUMENTS.
     &#x1F535; **MODULE STRUCTURE**:
     </template>
 
-    Find all modules (or OOP classes) and draw an Unicode-symbol based
-    "Boxes-and-Lines" diagram with all modules as boxes and the imports
-    between modules as the directed lines. Do not display any forther
+    Find all modules (or OOP classes) and draw a `flowchart TB`
+    diagram with all modules as boxes and the imports between modules
+    as the directed edges. Invoke the `ase-diagram` skill via the
+    `Skill` tool to render the diagram. Do not display any further
     explanation except for this diagram.
     </step>
 </flow>

--- a/plugin/skills/ase-diagram/SKILL.md
+++ b/plugin/skills/ase-diagram/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: ase-diagram
+description: "Render diagrams via the `ase diagram` CLI. Use whenever a response needs a structural, control-flow, state, sequence, class, entity-relationship, or metrics diagram. Enforces Mermaid source via stdin, no hand-drawn ASCII frames, ≤120-char rendered width, and verbatim stdout reproduction in the response."
+user-invocable: false
+disable-model-invocation: false
+effort: low
+allowed-tools:
+    - "Bash"
+---
+
+Render Diagrams
+===============
+
+Your role is to render *every* diagram in the current response through
+the `ase diagram` CLI, with deterministic and budget-compliant output.
+
+<objective>
+Produce a rendered diagram that the user can read directly in the
+response text, derived from Mermaid source piped through `ase diagram`
+via the `Bash` tool.
+</objective>
+
+*Note on naming*: `ase-diagram` (hyphen) is *this skill*; `ase diagram`
+(space) is the *CLI subcommand* this skill uses under the hood. The
+skill is invoked via the `Skill` tool; the CLI is invoked via the
+`Bash` tool inside the same response turn.
+
+Rules
+-----
+
+-   *NEVER hand-draw diagrams under any circumstances*.
+    Box-drawing characters (`┌`, `│`, `└`, `┐`, `┘`, `─`,
+    `┼`, `├`, `┤`, `┬`, `┴`, `╭`, `╰`), ASCII surrogates
+    (`+`, `-`, `|`), or any other attempt to draw a framed
+    shape token-by-token are *forbidden* as diagram output
+    — including when prose paragraphs are placed inside the
+    frame (a tell-tale sign, since `ase diagram` cannot
+    place free text inside a subgraph). Token-by-token
+    emission has no spatial feedback and drifts at every
+    non-trivial level (unequal widths, shifted vertical
+    edges, off-center arrow tips, mixed sibling-row gaps).
+
+-   *MUST use `ase diagram`*. Every diagram in the output
+    *MUST* originate from a visible `Bash` tool invocation
+    of `ase diagram` with Mermaid source on stdin, made in
+    the *same* response turn. The visible tool call is the
+    proof. *Self-check before emitting*: if your response
+    contains any of the box-drawing characters listed above
+    *without* a preceding `Bash(ase diagram ...)` tool call
+    in this same turn, you broke the rule — re-render via
+    the tool. The tool defaults to aligned Unicode box-
+    drawing; do *not* pass `--ascii`.
+
+-   *MUST reproduce the tool stdout in the response text*.
+    After the `Bash(ase diagram ...)` call completes, the
+    skill *MUST* copy the tool's stdout *verbatim* into a
+    Markdown fenced code block placed in the response text
+    immediately after the tool call. The terminal's Bash-
+    tool display is *collapsed* by default (`+N lines
+    (ctrl+o to expand)`) — the user reads the fenced block
+    in the response, not the tool display. *Both* must
+    appear. Emitting only the tool call without the
+    reproduction is a defect: the diagram is effectively
+    invisible.
+
+-   *Keep diagrams narrow* — target *≤120 chars rendered
+    width*. The renderer's horizontal extent scales with
+    siblings per row, node label lengths, and inter-node
+    padding. *Always* use `flowchart TB` (top-to-bottom) —
+    never `LR`, `RL`, or `BT` (portrait beats landscape for
+    terminals and code review diffs). Limit *siblings per
+    row* to *≤4* and group further items into nested
+    `subgraph` hierarchies; keep *node labels* *≤30 chars*
+    (abbreviate long names, drop adjectives). If the rendered
+    output still exceeds the budget, restructure the Mermaid
+    source — do *not* widen the terminal and do *not* raise
+    `--pad-x`/`--pad-y` (defaults `3`/`3` are already tight;
+    lower values break junction rendering).
+
+-   *Budget compliance is non-negotiable*. If restructuring
+    the Mermaid source cannot bring the rendered width
+    ≤120 chars (e.g., four populated `subgraph`s side by
+    side), *reduce scope*: show only the *top-level
+    structure* (the root node and ≤1 level of children) in
+    the diagram, and enumerate the detail as a bulleted
+    list *below* the rendered block. *Never* emit Mermaid
+    source as a substitute for a rendered diagram. The
+    choice is: render (possibly at reduced scope) or omit
+    the diagram entirely with a one-line note — *not* ship
+    unrendered source.
+
+-   *Keep edges inside subgraph boundaries*. An edge that
+    crosses a `subgraph` border produces a visually ambiguous
+    `┼` glyph where the border line (`─`) and the edge line
+    (`─`) collide — the box appears to merge into the arrow.
+    If a node has edges to peers *outside* a subgraph, either
+    move the node out of the subgraph or widen the subgraph
+    to include both endpoints. Never let arrows pierce
+    `subgraph` walls.
+
+-   For diagrams, choose the Mermaid type per intent:
+
+    -   *structure / layout / components / dependencies* → `flowchart TB`
+    -   *control flow / branching / concurrency*         → `flowchart TB`
+    -   *state machine / states / transitions*           → `stateDiagram-v2`
+    -   *data flow / actors / messages / protocols*      → `sequenceDiagram`
+    -   *data structure / classes / methods*             → `classDiagram`
+    -   *data model / entities / relationships*          → `erDiagram`
+    -   *metrics / distributions / time series*          → `xychart-beta`
+
+-   *Always* render diagrams inside a Markdown *fenced code block*
+    (triple backticks).
+
+-   For *comparison diagrams* (e.g., *current vs. proposed*,
+    *before vs. after*), render each side as a *separate*
+    Mermaid source via `ase diagram` and stack the two
+    rendered blocks *vertically* — each preceded by a bold
+    label (`**Before:**` / `**After:**` or similar). Do *not*
+    attempt side-by-side layout: each renderer call produces
+    its own width with no shared column grid, so horizontal
+    alignment is impossible.
+

--- a/tool/package.json
+++ b/tool/package.json
@@ -42,6 +42,7 @@
         "mkdirp":                           "3.0.1",
         "@hapi/hapi":                       "21.4.8",
         "axios":                            "1.15.1",
+        "beautiful-mermaid":                "1.1.3",
         "cli-table3":                       "0.6.5",
         "chalk":                            "5.6.2",
         "pretty-ms":                        "9.3.0",

--- a/tool/src/ase-diagram.ts
+++ b/tool/src/ase-diagram.ts
@@ -37,8 +37,8 @@ export default class DiagramCommand {
             .description("Render Mermaid source (stdin or --input) to aligned Unicode/ASCII diagram")
             .option("-a, --ascii",        "emit plain ASCII (+-|) instead of Unicode box-drawing", false)
             .option("-i, --input <file>", "read Mermaid source from file instead of stdin")
-            .option("-x, --pad-x <n>",    "horizontal spacing between nodes", "5")
-            .option("-y, --pad-y <n>",    "vertical spacing between nodes", "5")
+            .option("-x, --pad-x <n>",    "horizontal spacing between nodes", "3")
+            .option("-y, --pad-y <n>",    "vertical spacing between nodes", "3")
             .action(async (opts: DiagramOpts) => {
                 /*  load Mermaid source  */
                 let src: string
@@ -52,8 +52,8 @@ export default class DiagramCommand {
                 }
 
                 /*  parse spacing options  */
-                const paddingX = Number.parseInt(opts.padX ?? "5", 10)
-                const paddingY = Number.parseInt(opts.padY ?? "5", 10)
+                const paddingX = Number.parseInt(opts.padX ?? "3", 10)
+                const paddingY = Number.parseInt(opts.padY ?? "3", 10)
                 if (!Number.isFinite(paddingX) || !Number.isFinite(paddingY)) {
                     this.log.write("error", "diagram: --pad-x and --pad-y must be integers")
                     process.exit(1)

--- a/tool/src/ase-diagram.ts
+++ b/tool/src/ase-diagram.ts
@@ -1,0 +1,81 @@
+/*
+**  Agentic Software Engineering (ASE)
+**  Copyright (c) 2025-2026 Dr. Ralf S. Engelschall <rse@engelschall.com>, Matthias Brusdeylins <matthias@brusdeylins.info>
+**  Licensed under GPL 3.0 <https://spdx.org/licenses/GPL-3.0-only>
+*/
+
+import fs                     from "node:fs"
+
+import { Command }            from "commander"
+import { renderMermaidASCII } from "beautiful-mermaid"
+
+import type Log               from "./ase-log.js"
+
+interface DiagramOpts {
+    ascii?: boolean
+    input?: string
+    padX?:  string
+    padY?:  string
+}
+
+/*  read stdin into a single string  */
+const readStdin = async (): Promise<string> => {
+    const chunks: Buffer[] = []
+    for await (const chunk of process.stdin)
+        chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk)
+    return Buffer.concat(chunks).toString("utf8")
+}
+
+/*  command-line handling  */
+export default class DiagramCommand {
+    constructor (private log: Log) {}
+
+    /*  register commands  */
+    register (program: Command): void {
+        program
+            .command("diagram")
+            .description("Render Mermaid source (stdin or --input) to aligned Unicode/ASCII diagram")
+            .option("-a, --ascii",        "emit plain ASCII (+-|) instead of Unicode box-drawing", false)
+            .option("-i, --input <file>", "read Mermaid source from file instead of stdin")
+            .option("-x, --pad-x <n>",    "horizontal spacing between nodes", "5")
+            .option("-y, --pad-y <n>",    "vertical spacing between nodes", "5")
+            .action(async (opts: DiagramOpts) => {
+                /*  load Mermaid source  */
+                let src: string
+                if (opts.input !== undefined)
+                    src = fs.readFileSync(opts.input, "utf8")
+                else
+                    src = await readStdin()
+                if (src.trim() === "") {
+                    this.log.write("error", "diagram: empty Mermaid source")
+                    process.exit(1)
+                }
+
+                /*  parse spacing options  */
+                const paddingX = Number.parseInt(opts.padX ?? "5", 10)
+                const paddingY = Number.parseInt(opts.padY ?? "5", 10)
+                if (!Number.isFinite(paddingX) || !Number.isFinite(paddingY)) {
+                    this.log.write("error", "diagram: --pad-x and --pad-y must be integers")
+                    process.exit(1)
+                }
+
+                /*  render to ASCII  */
+                try {
+                    const out = renderMermaidASCII(src, {
+                        useAscii:  opts.ascii ?? false,
+                        colorMode: "none",
+                        paddingX,
+                        paddingY
+                    })
+                    process.stdout.write(out)
+                    if (!out.endsWith("\n"))
+                        process.stdout.write("\n")
+                }
+                catch (err: unknown) {
+                    const message = err instanceof Error ? err.message : String(err)
+                    this.log.write("error", `diagram: render failed: ${message}`)
+                    process.exit(1)
+                }
+            })
+    }
+}

--- a/tool/src/ase.ts
+++ b/tool/src/ase.ts
@@ -11,6 +11,7 @@ import type { LogLevel }           from "./ase-log.js"
 import ConfigCommand               from "./ase-config.js"
 import ServiceCommand              from "./ase-service.js"
 import HookCommand                 from "./ase-hook.js"
+import DiagramCommand              from "./ase-diagram.js"
 import pkg                         from "../package.json" with { type: "json" }
 
 /*  type of top-level (global) options  */
@@ -54,6 +55,7 @@ const main = async (): Promise<void> => {
     new ConfigCommand(log).register(program)
     new ServiceCommand(log).register(program)
     new HookCommand(log).register(program)
+    new DiagramCommand(log).register(program)
 
     /*  parse program arguments  */
     await program.parseAsync(process.argv)


### PR DESCRIPTION
## Summary

- Add `ase diagram` CLI subcommand that reads Mermaid source from stdin (or `--input`) and renders deterministic Unicode/ASCII output via `beautiful-mermaid` (ELK layout, MIT).
- Update the skill meta (`plugin/meta/ase-skill.md`) to mandate `ase diagram` for **every** diagram — hand-drawn Unicode emitted token-by-token has no spatial feedback and drifts at every non-trivial level (unequal widths, shifted vertical edges, off-center arrows, mixed sibling-row gaps).
- Tighten `ase-code-explain` STEP 3 accordingly; seed `plugin/settings.json` with a minimal allowlist entry for `Bash(ase diagram:*)` so the tool runs without per-invocation permission prompts.

## Rationale

Hand-drawn diagrams repeatedly failed alignment even with strict rules (character set, column counting, size budget). Routing through a layout engine removes the entire class of defects.

## Test plan

- [ ] `cd tool && npm start build` succeeds
- [ ] `echo 'graph LR; A-->B' | ase diagram` renders aligned Unicode boxes
- [ ] `ase diagram --ascii --input foo.mmd` renders ASCII fallback
- [ ] Invoking `ase-code-explain` on a sample target produces a diagram via `ase diagram` (not hand-drawn)