### PR TITLE
relax diagram width budget from 120 to 240 chars

### DIFF
--- a/plugin/skills/ase-meta-diagram/SKILL.md
+++ b/plugin/skills/ase-meta-diagram/SKILL.md
@@ -63,7 +63,7 @@ Rules
     without the reproduction of the output is a defect: the diagram is
     then effectively invisible.
 
--   *Keep diagrams narrow* — target a *≤120 chars rendering
+-   *Keep diagrams narrow* — target a *≤240 chars rendering
     width*. The renderer's horizontal extent scales with siblings
     per row, node label lengths, and inter-node padding. *Always*
     use `flowchart TB` (top-to-bottom) -— never `LR`, `RL`, or `BT`
@@ -77,7 +77,7 @@ Rules
     rendering).
 
 -   *Budget compliance is non-negotiable*. If restructuring the Mermaid
-    diagram specification cannot bring the rendered width ≤120 chars (e.g.,
+    diagram specification cannot bring the rendered width ≤240 chars (e.g.,
     four populated `subgraph`s side-by-side), *reduce scope*: show only
     the *top-level structure* (the root node and ≤1 level of children)
     in the diagram, and enumerate the detail as a bulleted list *below*


### PR DESCRIPTION
## Summary
- The 120-char rendering width budget in `ase-meta-diagram` is too restrictive for many practical diagrams.
- Even modest `flowchart TB` with 3-4 siblings per row and short labels can exceed it, forcing scope reduction or omission.
- Modern terminals and code-review viewports comfortably accommodate 240 chars.
- Sibling-per-row (≤4), node-label (≤30 chars), and `flowchart TB` portrait rule remain unchanged — only the width threshold is relaxed.

## Test plan
- [ ] Render a representative existing diagram and confirm it now fits the 240-char budget without scope reduction
- [ ] Confirm that diagrams previously inside the 120 budget are unaffected