### PR TITLE
warn LLM when ase diagram clips rendered output

### DIFF
--- a/tool/src/ase-diagram.ts
+++ b/tool/src/ase-diagram.ts
@@ -54,7 +54,7 @@ const parseColorMode = (name: string) => (value: string): "none" | "ansi16" | "a
 }
 
 /*  detect terminal column width  */
-const detectTermWidth = (): number => {
+export const detectTermWidth = (): number => {
     let width = 0
 
     /*  attempt 1: query environment variable  */
@@ -75,7 +75,7 @@ const detectTermWidth = (): number => {
 }
 
 /*  detect terminal row height  */
-const detectTermHeight = (): number => {
+export const detectTermHeight = (): number => {
     let height = 0
 
     /*  attempt 1: query environment variable  */
@@ -157,6 +157,30 @@ const truncateAnsiLine = (line: string, budget: number): string => {
     return out
 }
 
+/*  measure visible column width of a rendered line, ignoring ANSI escape
+    sequences (CSI ...m); mirrors the visibility model of truncateAnsiLine  */
+const visibleWidth = (line: string): number => {
+    let visible = 0
+    let i       = 0
+    while (i < line.length) {
+        const ch = line[i]!
+        if (ch === "\x1b" && line[i + 1] === "[") {
+            let j = i + 2
+            while (j < line.length && !/[A-Za-z]/.test(line[j]!))
+                j++
+            if (j < line.length) {
+                i = j + 1
+                continue
+            }
+            i++
+            continue
+        }
+        visible++
+        i++
+    }
+    return visible
+}
+
 /*  pure rendering helper: turn a Mermaid source string plus options into
     a rendered Unicode/ASCII diagram string. Throws on render failure.  */
 export const renderDiagram = (src: string, opts: DiagramRenderOpts): string => {
@@ -191,12 +215,34 @@ export const renderDiagram = (src: string, opts: DiagramRenderOpts): string => {
         const maxWidth   = termWidth  > 0 ? termWidth  - opts.diagramClipX : 0
         const maxHeight  = termHeight > 0 ? termHeight - opts.diagramClipY : 0
         const trailingNL = out.endsWith("\n")
-        let lines = (trailingNL ? out.slice(0, -1) : out).split("\n")
-        if (maxWidth > 0)
+        let lines        = (trailingNL ? out.slice(0, -1) : out).split("\n")
+        let widthWarn    = ""
+        let heightWarn   = ""
+        if (maxWidth > 0) {
+            const widest = lines.reduce((m, l) => Math.max(m, visibleWidth(l)), 0)
+            if (widest > maxWidth)
+                widthWarn =
+                    `ase diagram: WARNING: rendered diagram width ${widest} exceeds budget ${maxWidth}; ` +
+                    "rightmost content was clipped. Please regenerate the Mermaid source to fit " +
+                    `within ${maxWidth} chars by preferring a portrait orientation ` +
+                    "(\"flowchart TB\", top-to-bottom) over landscape (\"LR\"/\"RL\"/\"BT\"), " +
+                    "reducing siblings per row, abbreviating node labels, or restructuring " +
+                    "into nested subgraph hierarchies."
             lines = lines.map((l) => truncateAnsiLine(l, maxWidth))
-        if (maxHeight > 0 && lines.length > maxHeight)
+        }
+        if (maxHeight > 0 && lines.length > maxHeight) {
+            const overflow = lines.length - maxHeight
+            heightWarn =
+                `ase diagram: WARNING: rendered diagram height ${lines.length} exceeds budget ${maxHeight}; ` +
+                `bottom ${overflow} line(s) were clipped. Please regenerate the Mermaid source to fit ` +
+                `within ${maxHeight} lines by reducing depth or splitting into multiple diagrams.`
             lines = lines.slice(0, maxHeight)
+        }
         out = lines.join("\n") + (trailingNL ? "\n" : "")
+        if (widthWarn !== "")
+            out += "\n" + widthWarn + "\n"
+        if (heightWarn !== "")
+            out += "\n" + heightWarn + "\n"
     }
 
     return out

--- a/tool/src/ase-service.ts
+++ b/tool/src/ase-service.ts
@@ -25,7 +25,11 @@ import { z }                             from "zod"
 
 import { Config, configSchema, parseScope } from "./ase-config.js"
 import type Log                 from "./ase-log.js"
-import { renderDiagram }        from "./ase-diagram.js"
+import {
+    renderDiagram,
+    detectTermWidth,
+    detectTermHeight
+}                               from "./ase-diagram.js"
 import { taskLoad, taskSave, taskDelete, taskList } from "./ase-task.js"
 import pkg                      from "../package.json" with { type: "json" }
 
@@ -262,10 +266,10 @@ export default class ServiceCommand {
                         .describe("extra horizontal clipping: subtract this many characters from `terminalWidth`"),
                     diagramClipY: z.number().int().min(0).default(0)
                         .describe("extra vertical clipping: subtract this many lines from `terminalHeight`"),
-                    terminalWidth: z.number().int().min(0).default(0)
-                        .describe("terminal width in characters; 0 disables horizontal clipping"),
-                    terminalHeight: z.number().int().min(0).default(0)
-                        .describe("terminal height in lines; 0 disables vertical clipping")
+                    terminalWidth: z.number().int().min(0).default(detectTermWidth())
+                        .describe("terminal width in characters; 0 disables horizontal clipping; defaults to ASE_TERM_WIDTH env var if set"),
+                    terminalHeight: z.number().int().min(0).default(detectTermHeight())
+                        .describe("terminal height in lines; 0 disables vertical clipping; defaults to ASE_TERM_HEIGHT env var if set")
                 }
             }, async (args) => {
                 try {


### PR DESCRIPTION
## Summary

- Currently `renderDiagram()` silently clips rendered output that exceeds `terminalWidth` / `terminalHeight`. The LLM (or human reader) gets no signal that content was lost on the right (or bottom), so cannot react by regenerating the Mermaid source.
- This PR appends an actionable warning to the rendered output (separated by a blank line below the diagram) whenever clipping occurred. The warning text is imperative so the LLM can act on it directly: regenerate with portrait orientation over landscape, fewer siblings per row, shorter labels, nested subgraphs, or split into multiple diagrams.
- Warning is appended to **stdout** (not stderr) so it ends up inside the skill's mandated stdout-verbatim Markdown fenced block — both LLM and human reader see it.
- Additionally aligns the MCP `diagram` tool defaults for `terminalWidth` / `terminalHeight` with the CLI path: replaces the static `0` (no clipping) defaults with `detectTermWidth()` / `detectTermHeight()` so `ASE_TERM_WIDTH` / `ASE_TERM_HEIGHT` env vars are honored on the MCP path too. Note: env vars are evaluated once at `registerTool` time (i.e. at service start), so the persistent service must be restarted for env changes to take effect.

## Test plan

- [x] CLI: `echo '...' | ase diagram --terminal-width 20` → warning appears, diagram clipped
- [x] MCP: `mcp__plugin_ase_ase__diagram` with `terminalWidth: 25` → warning appears, diagram clipped
- [x] Schema-default `terminalWidth: 200` reads from `ASE_TERM_WIDTH=200` env var at service start
- [x] Boundary: diagram fits within budget → no warning
- [x] Height-only overflow → only height warning
- [x] Both width + height overflow → both warnings stacked