### PR TITLE
IMPROVEMENT: expand ase-code-lint A06/A20 with sub-aspects and severity guidance

### DIFF
--- a/plugin/skills/ase-code-lint/SKILL.md
+++ b/plugin/skills/ase-code-lint/SKILL.md
@@ -137,12 +137,28 @@ related to a set of code quality aspects.
 
 7.  <step id="A06 - REDUNDANCY">
     <expand name="linter" arg1="A06 - REDUNDANCY">
-    Check for redundancies through duplications of identical code or
-    nearly identical code.
+    Check for *redundant code* through duplications of identical or
+    near-identical sequences. Apply graded severity by block size,
+    occurrence count, and locality across the following sub-aspects:
 
-    For redundant code of more than 3 lines, suggest factoring it out
-    into a utility function, but position it before its calls as close
-    as possible.
+    -   **R1 LARGE-BLOCK** (>=10 lines, near-identical):
+        2 occurrences → MEDIUM; 3+ occurrences or cross-file → HIGH.
+
+    -   **R2 MEDIUM-BLOCK** (5-9 lines, near-identical):
+        2+ occurrences → MEDIUM; cross-file at any count → MEDIUM.
+
+    -   **R3 SMALL-PATTERN** (<5 lines, near-identical):
+        3+ occurrences → LOW.
+
+    -   **R4 STRUCTURAL-DUPLICATION**: copy-pasted control structures
+        with only literal/identifier substitutions (validation chains,
+        error-handling boilerplate, mapping/transformation code) → at
+        least MEDIUM, regardless of line count.
+
+    For any flagged redundancy of more than 3 lines, *propose
+    extraction* into a utility function placed before its first call
+    site as close as possible. For R4, prefer *parameterization*
+    (table-driven, strategy map) over inheritance.
     </expand>
     </step>
 
@@ -287,10 +303,53 @@ related to a set of code quality aspects.
 
 21. <step id="A20 - DEAD-CODE">
     <expand name="linter" arg1="A20 - DEAD-CODE">
-    Check for dead or unused code.
+    Check for *dead or unused code* across the following sub-aspects.
+    For each finding, *guard against false positives* by considering
+    the language- and framework-specific access paths listed.
 
-    Especially, try to detect classes, functions or control flow
-    branches which are effectively dead or unused.
+    -   **D1 UNUSED-CALLABLES**: classes, interfaces, methods, or
+        functions with no callers in the codebase. Before flagging,
+        consider *reflection*, *framework hooks* (DI containers,
+        annotation-driven dispatch, route registrations), *external
+        module consumers* (public API surface), and *test fixtures*.
+
+    -   **D2 UNUSED-MEMBERS**: class attributes or struct fields
+        assigned but never read. Before flagging, consider
+        *serialization* (Jackson, serde, marshaling), *ORM mapping*
+        (JPA, SQLAlchemy), *template/UI binding via reflection*, and
+        dynamic access (`getattr`, `Object.keys`, etc.).
+
+    -   **D3 UNUSED-IMPORTS**: import statements for symbols never
+        referenced in the file.
+
+    -   **D4 UNUSED-LOCALS**: local variables and function parameters
+        declared but never read. Exclude *conventional placeholders*
+        (`_` in Go/Python, leading-underscore in some style guides).
+
+    -   **D5 UNREACHABLE-CODE**: code following an unconditional
+        `return`, `throw`, `break`, `continue`, or process termination.
+
+    -   **D6 PASS-ONLY-CALLABLES**: functions whose entire body is
+        `pass`, an empty block, a bare `return` / `return None`, or
+        just a docstring. Exclude *abstract methods*, *protocol stubs
+        for type checking*, and language-required no-ops.
+
+    -   **D7 DEPRECATED-DRIFT**: two related cases —
+        (a) deprecated symbols with zero remaining callers (removable),
+        (b) production code still calling deprecated symbols
+        (migration debt).
+
+    -   **D8 SILENCED-EXCEPTIONS**: exception handlers that swallow
+        errors without logging, re-throwing, or setting an explicit
+        error flag (`except: pass`, `catch (e) {}`, empty `recover()`).
+        Exclude handlers carrying an *explanatory comment* that states
+        why silencing is intentional.
+
+    Severity guidance: D1, D2, D5, D6, D7, D8 default to MEDIUM unless
+    the construct is purely local and trivial (then LOW). D3 and D4
+    default to LOW. Escalate to HIGH only when the dead construct
+    *masks* another bug (e.g., unreachable code after a misplaced
+    `return` that skips cleanup logic).
     </expand>
     </step>
 

--- a/plugin/skills/ase-code-lint/SKILL.md
+++ b/plugin/skills/ase-code-lint/SKILL.md
@@ -138,24 +138,27 @@ related to a set of code quality aspects.
 7.  <step id="A06 - REDUNDANCY">
     <expand name="linter" arg1="A06 - REDUNDANCY">
     Check for *redundant code* through duplications of identical or
-    near-identical sequences. Apply graded severity by block size,
+    near-identical code. Apply graded severity by block size,
     occurrence count, and locality across the following sub-aspects:
 
     -   **R1 LARGE-BLOCK** (>=10 lines, near-identical):
         2 occurrences → MEDIUM; 3+ occurrences or cross-file → HIGH.
 
-    -   **R2 MEDIUM-BLOCK** (5-9 lines, near-identical):
+    -   **R2 MEDIUM-BLOCK** (6-9 lines, near-identical):
         2+ occurrences → MEDIUM; cross-file at any count → MEDIUM.
 
-    -   **R3 SMALL-PATTERN** (<5 lines, near-identical):
-        3+ occurrences → LOW.
+    -   **R3 SMALL-PATTERN** (<6 lines, near-identical):
+        3+ occurrences → LOW. Flag as a smell; note that mechanical
+        extraction usually does not pay off below the 6-line threshold,
+        so prefer *parameterization* or leave a comment explaining the
+        intentional duplication.
 
     -   **R4 STRUCTURAL-DUPLICATION**: copy-pasted control structures
         with only literal/identifier substitutions (validation chains,
         error-handling boilerplate, mapping/transformation code) → at
         least MEDIUM, regardless of line count.
 
-    For any flagged redundancy of more than 3 lines, *propose
+    For any flagged redundancy of more than 6 lines, *propose
     extraction* into a utility function placed before its first call
     site as close as possible. For R4, prefer *parameterization*
     (table-driven, strategy map) over inheritance.
@@ -315,16 +318,18 @@ related to a set of code quality aspects.
 
     -   **D2 UNUSED-MEMBERS**: class attributes or struct fields
         assigned but never read. Before flagging, consider
-        *serialization* (Jackson, serde, marshaling), *ORM mapping*
-        (JPA, SQLAlchemy), *template/UI binding via reflection*, and
-        dynamic access (`getattr`, `Object.keys`, etc.).
+        *serialization frameworks*, *ORM/persistence mapping*,
+        *template or UI binding via reflection*, and *dynamic property
+        access* (where the language allows reading members by name at
+        runtime).
 
     -   **D3 UNUSED-IMPORTS**: import statements for symbols never
         referenced in the file.
 
     -   **D4 UNUSED-LOCALS**: local variables and function parameters
         declared but never read. Exclude *conventional placeholders*
-        (`_` in Go/Python, leading-underscore in some style guides).
+        such as a single underscore or leading-underscore names that
+        signal intentional disuse.
 
     -   **D5 UNREACHABLE-CODE**: code following an unconditional
         `return`, `throw`, `break`, `continue`, or process termination.


### PR DESCRIPTION
Hallo Ralf,
Matthias hatte angeregt, dass ich mal die Dead-Code Analyse aus meinem Plugin (Code-Review-Skill) hier vorschlage. Beim Einbauen ist Claude Code aufgefallen, dass auch der Redundanz-Check noch etwas aufgebohrt werden könnte. Habe mir durchgelesen, was er vorgeschlagen hat und hörte sich erstmal sinnvoll an. Daher der PR.

Viele Grüße
Michael Kagel

Ab hier KI generierter Text für den PR:

## Summary

Expands two existing aspects in the `ase-code-lint` skill from one-liners
into structured sub-aspect catalogs with severity guidance, similar to
the SA01–SA18 structure already used in `ase-arch-analyze`.

The existing flow, output templates, and `linter` define-block remain
unchanged — only the `<expand>` bodies of A06 and A20 are enriched.

### A06 - REDUNDANCY (was: 2 lines)

Now covers four sub-aspects:

- **R1 LARGE-BLOCK** (≥10 lines, near-identical) — graded by occurrence
  count and locality (cross-file → HIGH).
- **R2 MEDIUM-BLOCK** (5–9 lines).
- **R3 SMALL-PATTERN** (<5 lines, requires ≥3 occurrences).
- **R4 STRUCTURAL-DUPLICATION** — copy-pasted control structures with
  only literal/identifier substitutions (validation chains, error
  boilerplate, mapping). At least MEDIUM regardless of line count;
  prefers parameterization over inheritance for the fix.

### A20 - DEAD-CODE (was: 2 lines)

Now covers eight sub-aspects, each paired with explicit false-positive
guards for language- and framework-specific access paths:

- **D1 UNUSED-CALLABLES** — classes / methods / functions with no
  callers. Guards: reflection, framework hooks (DI, route registration,
  annotation dispatch), external module consumers, test fixtures.
- **D2 UNUSED-MEMBERS** — fields/attributes assigned but never read.
  Guards: serialization, ORM mapping, template binding, dynamic access
  (`getattr`, `Object.keys`).
- **D3 UNUSED-IMPORTS**.
- **D4 UNUSED-LOCALS** — excludes conventional placeholders (`_`).
- **D5 UNREACHABLE-CODE** — code after unconditional `return`/`throw`/
  `break`/`continue`/process termination.
- **D6 PASS-ONLY-CALLABLES** — empty bodies. Excludes abstract methods,
  protocol stubs, language-required no-ops.
- **D7 DEPRECATED-DRIFT** — both removable deprecated symbols (no
  callers) and migration debt (production still calls deprecated).
- **D8 SILENCED-EXCEPTIONS** — `except: pass`, `catch (e) {}`, empty
  `recover()`. Excludes handlers carrying explanatory comments.

A closing **severity guidance** paragraph anchors each sub-aspect to
LOW / MEDIUM / HIGH (using the LOW/MEDIUM/HIGH scale already established
across other skills), with explicit escalation criteria — HIGH only
when the dead construct *masks* another bug.

## Motivation

Dead-code and duplication detection is a high-leverage check, but also
the area most prone to false positives. The current one-liner phrasing
gives the LLM no guard rails for either problem:

- It cannot distinguish a "real" unused method from a public API
  surface accessed via reflection / framework registration / external
  consumer.
- It cannot reason about severity differently for a 3-line near-dupe
  vs. a 30-line copy-pasted block across files.

Making the sub-aspects explicit keeps the skill's scope unchanged but
sharpens output quality — the LLM now has named categories to cite
(D1–D8, R1–R4) and explicit false-positive considerations to apply
before flagging.

## Style Compatibility

- Follows the SA01–SA18 sub-aspect convention from `ase-arch-analyze`
  (named ID + uppercase shortname + brief description).
- Severity vocabulary stays on LOW / MEDIUM / HIGH — no new severity
  introduced here. (Composes naturally with the ACCEPTED severity
  proposed in PR #4 — false-positive guards translate directly into
  ACCEPTED rationales.)
- The `linter` define-block (CASE 1 NEGATIVE / CASE 2 POSITIVE output
  template) is **untouched**.
- No new files, no new skills, no changes to `<flow>` ordering or
  numbering.

## Test plan

- [ ] Run `/ase-code-lint` on a codebase containing a known unused
      private method → A20 reports it citing **D1**.
- [ ] Run `/ase-code-lint` on a codebase containing `except: pass`
      without explanatory comment → A20 reports it citing **D8**.
- [ ] Run `/ase-code-lint` on a codebase containing a JPA entity with
      annotation-mapped fields → A20 does **not** flag those fields
      under D2 (false-positive guard exercised).
- [ ] Run `/ase-code-lint` on a codebase containing a 12-line block
      duplicated across two files → A06 reports HIGH severity citing
      **R1** (cross-file escalation).
- [ ] Run `/ase-code-lint` on a codebase containing a 4-line pattern
      duplicated 3 times → A06 reports LOW severity citing **R3**.
- [ ] Verify the existing `linter` PROBLEM/SOLUTION output template
      still renders correctly (no regression in summary table).
