### PR TITLE
fix(constitution): make semicolon and brace prohibitions language-aware

### DIFF
--- a/plugin/meta/ase-constitution.md
+++ b/plugin/meta/ase-constitution.md
@@ -19,12 +19,12 @@ Prohibitions
 ------------
 
 - Do *not* factor out (move) code into own functions without good reason, like necessary reusability.
-- Do *not* use braces arround single statement blocks in "if" and "while" constructs.
+- Do *not* use braces around single statement blocks in "if" and "while" constructs unless the language requires them.
 - Do *not* insist on early "return" in "if" blocks if an "else" block exists.
 - Do *not* remove any whitespaces in the code formatting -- keep whitespaces align with code base.
-- Do *not* show just partial code changes -- always show comlete changes.
+- Do *not* show just partial code changes -- always show complete changes.
 - Do *not* produce any line which consists of just one or more space characters before the newline -- use just the newline.
-- Do *not* use semicolons in the source at all, except inside `for` clauses.
+- Do *not* use semicolons where they are syntactically optional, except inside `for` clauses.
 - Do *not* split continuous chunks of code less than 100 lines into individual functions.
 - Do *not* refactor deeply nested code constructs into individual functions.
 - Do *not* answer with the "You're absolutely right", "You are


### PR DESCRIPTION
## Summary

Reformulates two prohibitions in `plugin/meta/ase-constitution.md` so they apply correctly across **all supported languages** without enumerating them.

The current wording is implicitly tied to languages where semicolons and single-statement braces are optional (Kotlin, JavaScript/TypeScript, Go for semicolons, Java/C/C++/C# for braces). When Claude follows the constitution mechanically against a mandatory-semicolon language (Java, C, C++, C#, Rust, PHP) or a mandatory-brace language (Go, Rust), the result is non-compilable code.

Triggered by an iTWS Java refactor where the semicolon rule was applied across the board and the build broke until a manual correction.

### Changes (line 22 + 27, plus typo line 25)

**Line 22 — brace rule:**

- before: `Do *not* use braces arround single statement blocks in "if" and "while" constructs.`
- after: `Do *not* use braces around single statement blocks in "if" and "while" constructs unless the language requires them.`

**Line 25 — typo:**

- before: `Do *not* show just partial code changes -- always show comlete changes.`
- after: `Do *not* show just partial code changes -- always show complete changes.`

**Line 27 — semicolon rule:**

- before: ``Do *not* use semicolons in the source at all, except inside `for` clauses.``
- after: ``Do *not* use semicolons where they are syntactically optional, except inside `for` clauses.``

### Design choice

Both rules use a short language-neutral escape clause (`unless the language requires them` / `where they are syntactically optional`) instead of enumerating concrete languages. This:

- preserves the original intent (no redundant terminators, no unnecessary braces)
- defers to the language's required syntax wherever it would conflict
- keeps the prohibitions list one-liner-per-rule, matching the existing style
- avoids a maintenance burden of keeping language lists current

### Drive-by

Two typos fixed in adjacent prohibitions: `arround` → `around` (line 22) and `comlete` → `complete` (line 25).

## Test plan

- [ ] Verify rendered constitution in a new Claude Code session shows the updated wording
- [ ] Spot-check a Java edit: Claude keeps semicolons and braces as the language requires
- [ ] Spot-check a TypeScript edit: Claude still avoids optional semicolons and unnecessary single-statement braces

🤖 Generated with [Claude Code](https://claude.com/claude-code)