### PR TITLE
feat(arch-analyze): add package-cohesion audit (Block 7, SA19-SA21)

### DIFF
--- a/plugin/skills/ase-arch-analyze/SKILL.md
+++ b/plugin/skills/ase-arch-analyze/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ase-arch-analyze
 argument-hint: "<source-reference>"
-description: Review software architecture
+description: Review software architecture, including package cohesion and inter-package coupling
 user-invocable: true
 disable-model-invocation: false
 model: opus
@@ -200,6 +200,33 @@ interface quality, quality attributes, and architecture governance.
      The chosen style, deviations from defaults, and trade-offs are
      traceable.
 
+   **Block 7 — Package Cohesion**
+   - **SA19 PACKAGE-COHESION**: each first-party package has a
+     coherent role *and* topical theme — its members serve a
+     common purpose, share a dominant noun-cluster, and have
+     non-trivial cross-package use. Flag:
+     - *grab-bag*: members split into ≥3 unrelated topical
+       clusters (e.g. a `util` package mixing date-parsing,
+       network-retry, and string-formatting helpers)
+     - *misplaced class*: a class only imported once cross-package
+       but referenced *≥3 times* inside the consumer (likely
+       belongs in the consumer or in a shared utility package)
+     - *topical outlier*: a class whose name-tokens share *<30%*
+       overlap with the package's dominant noun-cluster, or with
+       its `package-info` / `README` declaration when present
+   - **SA20 PACKAGE-CYCLE**: no *cyclic dependencies* between
+     first-party packages — neither direct (`A → B` and `B → A`)
+     nor transitive (via *Tarjan SCC* or pairwise scan). Each
+     cycle is reported with the exact import lines that close it.
+   - **SA21 PACKAGE-SIZE**: package size and coupling shape are
+     justified — flag packages at either extreme:
+     - *god-package*: *incoming ≥ 5* and *outgoing ≥ 3* —
+       coordinator dumping ground that should be split along its
+       internal topical clusters
+     - *fragment*: 1–2 files under a sibling parent that share a
+       *name prefix* or *imported interface* with that sibling —
+       consolidation candidate
+
    Hints:
 
    - During investigation, do *not* output anything else,
@@ -221,6 +248,22 @@ interface quality, quality attributes, and architecture governance.
      pattern-match on "loop inside method with lock" — verify
      which operations sit *between* the specific acquire and
      release in source order.
+
+   - *Package-graph construction (SA19–SA21)*: parse each file's
+     import (or equivalent language construct) statement, keep
+     only first-party packages within the analysed scope, and
+     persist two intermediate structures: the per-package
+     incoming/outgoing class-edge map (drives SA20, SA21) and
+     the per-package noun-token frequency table extracted from
+     class names in camelCase / snake_case (drives SA19 topical
+     analysis). No external NLP — pure tokens. Cite each finding
+     with the exact import lines or class-name evidence.
+
+   - *Block 7 severity ladder*: SA20 (cycle) → HIGH; SA21
+     (size/shape) → MEDIUM; SA19 (cohesion) → LOW. Mark ACCEPTED
+     when `CLAUDE.md`, `AGENTS.md`, `package-info`, or class
+     Javadoc explicitly justifies the pattern (per skill-meta
+     contract-already-addressed rule).
    </step>
 
 2. <step id="STEP 2: Show Architecture Overview">


### PR DESCRIPTION
## Summary

Extends `ase-arch-analyze` with a new audit block (**Block 7 — Package Cohesion**) that covers the three dimensions of clean packaging — *content coherence*, *dependency direction*, and *size/coupling shape* — in three consolidated audit aspects.

The original intent of *package cohesion* is not just to flag god-packages by edge counts, but also to enforce that package members are **inhaltlich** (topically) coherent. Block 7 makes both dimensions explicit:

| Aspect | Dimension | Severity | What it flags |
|---|---|---|---|
| **SA19 PACKAGE-COHESION** | content | LOW | grab-bags, misplaced classes, topical outliers |
| **SA20 PACKAGE-CYCLE** | dependency | HIGH | direct + transitive cycles (Tarjan SCC) |
| **SA21 PACKAGE-SIZE** | length / shape | MEDIUM | god-packages and fragments |

### Why three aspects

An earlier draft had six audit aspects (SA19–SA24). Each was justified individually but together they over-fragmented Block 7 along count-based heuristics that all served the same root concern. The three aspects above absorb those sub-heuristics as bullet points under the right top-level concern, keeping the same checking depth without inflating the SA-numbering range.

### Implementation hints

The skill includes two block-level hints:

- **Package-graph construction (SA19–SA21)**: parse each file's `import` statement, keep only first-party packages within scope, and persist two intermediate structures — the per-package incoming/outgoing class-edge map (drives SA20, SA21) and the per-package noun-token frequency table extracted from class names in camelCase / snake_case (drives SA19 topical analysis). No external NLP — pure tokens.
- **Severity ladder**: SA20 → HIGH (cycles break compile / test ordering), SA21 → MEDIUM (architecture smell), SA19 → LOW (refactor signal). All Block 7 findings can be marked ACCEPTED when `CLAUDE.md`, `AGENTS.md`, `package-info`, or class Javadoc explicitly justifies the pattern.

### Files

Single file changed: `plugin/skills/ase-arch-analyze/SKILL.md` — 44 insertions, 1 deletion.

The skill description was widened to *"Review software architecture, including package cohesion and inter-package coupling"* so users see the broader scope when listing skills.

## Test plan

- [ ] Run `/ase-arch-analyze <java-multi-package-scope>` on a project known to have a cyclic package dependency and verify SA20 fires with the closing import lines cited
- [ ] Run on a project with a `util` grab-bag package and verify SA19 flags the topical clusters
- [ ] Run on a project with a coordinator package importing many siblings and verify SA21 flags it as god-package
- [ ] Verify ACCEPTED gate honours `package-info.java` Javadoc justification

🤖 Generated with [Claude Code](https://claude.com/claude-code)