### PR TITLE
github copilot: support for powershell

### DIFF
--- a/plugin/hooks/hooks-copilot.json
+++ b/plugin/hooks/hooks-copilot.json
@@ -3,20 +3,23 @@
     "hooks": {
         "sessionStart": [
             {
-                "type":   "command",
-                "bash":   "ase hook session-start --tool copilot"
+                "type":       "command",
+                "bash":       "ase hook session-start --tool copilot",
+                "powershell": "ase hook session-start --tool copilot"
             }
         ],
         "sessionEnd": [
             {
-                "type":   "command",
-                "bash":   "ase hook session-end --tool copilot"
+                "type":       "command",
+                "bash":       "ase hook session-end --tool copilot",
+                "powershell": "ase hook session-end --tool copilot"
             }
         ],
         "preToolUse": [
             {
-                "type":   "command",
-                "bash":   "ase hook pre-tool-use --tool copilot"
+                "type":       "command",
+                "bash":       "ase hook pre-tool-use --tool copilot",
+                "powershell": "ase hook pre-tool-use --tool copilot"
             }
         ]
     }


### PR DESCRIPTION
Support if only Windows/Powershell is used with Github Copilot.

More Information:
https://awesome-copilot.github.com/learning-hub/automating-with-hooks/

bash: The command or script to execute on Unix systems. Can be inline or reference a script file.
powershell: The command or script to execute on Windows systems. Either bash or powershell (or both) must be provided.

FYI: You can use "command" instead of explicitly specifying "powershell" or "bash." However, this option is not documented or officially supported. "command" is automatically mapped to "powershell" and "bash." Github Copilot CLI makes the decision:

  if (hookConfig.bash && hookConfig.powershell) {
    shell = process.platform === "win32" ? "powershell" : "bash";
  } else if (hookConfig.bash) {
    shell = "bash";
  } else if (hookConfig.powershell) {
    shell = "powershell";
  } else {
    throw new Error("Neither 'bash' nor 'powershell' specified");
  }