### PR TITLE
Fix malformed markdown with duplicate entry with key "tools"

### DIFF
--- a/plugin/agents/ase-meta-search.md
+++ b/plugin/agents/ase-meta-search.md
@@ -7,11 +7,6 @@ tools:
     - "WebSearch"
 model: sonnet
 effort: low
-tools:
-    - "mcp__search-perplexity__perplexity_search"
-    - "mcp__search-brave__brave_web_search"
-    - "mcp__search-exa__web_search_exa"
-    - "WebSearch"
 ---
 
 Just perform the given *query* `$ARGUMENTS` and


### PR DESCRIPTION
**Be aware** that "mcp__search-exa__web_search_exa" will also be removed.

Reason: ase-meta-search.md: custom agent markdown frontmatter is malformed: failed to parse YAML frontmatter: duplicate entry with key "tools"