### PR TITLE
fix(statusline): accept numeric Unix timestamp for rate-limit resets_at

### DIFF
--- a/tool/src/ase-statusline.ts
+++ b/tool/src/ase-statusline.ts
@@ -78,11 +78,11 @@ interface StatuslineInput {
     rate_limits?: {
         five_hour?: {
             used_percentage?: number,
-            resets_at?: string
+            resets_at?: string | number
         }
         seven_day?: {
             used_percentage?: number,
-            resets_at?: string
+            resets_at?: string | number
         }
     }
 }
@@ -178,9 +178,19 @@ const formatHoursMinutes = (ms: number): string => {
     return `${hours}hr ${mins}m`
 }
 
-/*  format an ISO timestamp as a remaining-time relative to now (e.g. 4hr 27m, 6d 12hr 7m)  */
-const formatTimeUntil = (iso: string): string => {
-    const target = Date.parse(iso)
+/*  format an ISO timestamp or numeric Unix timestamp as a remaining-time relative to now (e.g. 4hr 27m, 6d 12hr 7m)  */
+const formatTimeUntil = (when: string | number | undefined): string => {
+    let target: number
+    if (typeof when === "number") {
+        if (!Number.isFinite(when))
+            return ""
+        /*  values below 1e12 are Unix seconds, otherwise milliseconds  */
+        target = when < 1e12 ? when * 1000 : when
+    }
+    else if (typeof when === "string")
+        target = Date.parse(when)
+    else
+        return ""
     if (!Number.isFinite(target))
         return ""
     const delta = target - Date.now()
@@ -472,7 +482,7 @@ export default class StatuslineCommand {
                             emit(`${prefix("⏲", "session-usage")}${c.bold(`${pct5h.toFixed(1)}%`)}`)
                     },
                     D: () => {
-                        const until5h = data.rate_limits?.five_hour?.resets_at ?? ""
+                        const until5h = data.rate_limits?.five_hour?.resets_at
                         const s       = formatTimeUntil(until5h)
                         if (s !== "")
                             emit(`${prefix("⏱", "session-resets")}${c.bold(s)}`)
@@ -483,7 +493,7 @@ export default class StatuslineCommand {
                             emit(`${prefix("⏲", "weekly-usage")}${c.bold(`${pctWk.toFixed(1)}%`)}`)
                     },
                     Q: () => {
-                        const untilWk = data.rate_limits?.seven_day?.resets_at ?? ""
+                        const untilWk = data.rate_limits?.seven_day?.resets_at
                         const s       = formatTimeUntil(untilWk)
                         if (s !== "")
                             emit(`${prefix("⏱", "weekly-resets")}${c.bold(s)}`)


### PR DESCRIPTION
## Problem

The statusline placeholders `%D` (session-resets) and `%Q` (weekly-resets) render empty.

Claude Code sends `rate_limits.five_hour.resets_at` and `rate_limits.seven_day.resets_at` as a **numeric Unix timestamp** (seconds, e.g. `1780765200`), but `formatTimeUntil()` only handled ISO strings via `Date.parse()`. A number passed to `Date.parse()` yields `NaN`, so the placeholder collapses to `""`.

## Fix

- Widen the `rate_limits.*.resets_at` schema type to `string | number`.
- `formatTimeUntil()` now accepts `string | number | undefined`:
  - **number** → interpreted as Unix time; heuristic: values `< 1e12` are seconds (×1000), otherwise milliseconds.
  - **string** → unchanged `Date.parse()` path.
  - **invalid/undefined** → `""` (behaviour unchanged).
- Drop the `?? ""` coercion at the `%D`/`%Q` call sites so a numeric value passes through cleanly instead of being forced into an empty string.

## Verification (manual)

Built tool, piped synthetic payloads through `ase statusline ... '%S %D'` / `'%W %Q'`:

| Input | Result |
|---|---|
| numeric seconds (`now+10800`) | `session-resets: 2hr 59m` ✅ |
| numeric milliseconds (`now_ms+7200000`) | `session-resets: 1hr 59m` ✅ |
| ISO string (`+90min`) | `session-resets: 1hr 29m` ✅ |
| no `resets_at` | empty (only usage shown) ✅ |
| weekly numeric seconds (`now+172800`) | `weekly-resets: 1d 23hr 59m` ✅ |

Lint + build green (`npm --prefix tool start build`).

## Notes

No unit test added: the `tool/` project has no test framework or test target (only `lint` + `tsc` build, per `AGENTS.md`). Verification was done manually against the built CLI as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)