### PR TITLE
setup: auto-detect plugin installation scope when --scope is omitted

### DIFF
--- a/docs/usage-tool.md
+++ b/docs/usage-tool.md
@@ -302,14 +302,18 @@ uninstalling the *ASE* tool and its companion *Anthropic Claude Code CLI* plugin
   without uninstalling it.
 
   All of `install`, `update`, `uninstall`, `enable`, and `disable` also
-  accept \[`-s`|`--scope` `user`|`project`|`local`\] (default: `user`)
-  to select the plugin installation scope: `user` registers the plugin
-  globally for the current user, `project` registers it in the project
-  and is meant to be shared via version control, and `local` registers
-  it in the project but keeps it out of version control. `--scope` is
-  only supported for `--tool claude`; requesting a non-`user` scope for
-  `copilot` or `codex` fails with an error, since those agent tools have
-  no scope concept.
+  accept \[`-s`|`--scope` `user`|`project`|`local`\] to select the plugin
+  installation scope: `user` registers the plugin globally for the
+  current user, `project` registers it in the project and is meant to be
+  shared via version control, and `local` registers it in the project
+  but keeps it out of version control. For `install` the default is
+  `user`; for `update`, `uninstall`, `enable`, and `disable` the scope
+  is auto-detected from the existing installation (the strongest of
+  `local`, `project`, or `user` whose settings file registers the
+  plugin), falling back to `user` when no installation is found.
+  `--scope` is only supported for `--tool claude`; requesting a
+  non-`user` scope for `copilot` or `codex` fails with an error, since
+  those agent tools have no scope concept.
 
 - `ase setup mcp`:
   Entry point group for managing the pre-defined *foreign MCP servers*

--- a/tool/src/ase-setup.ts
+++ b/tool/src/ase-setup.ts
@@ -931,6 +931,47 @@ export default class SetupCommand {
             throw new Error("--scope is only supported for --tool claude")
     }
 
+    /*  auto-detect the scope in which the ASE plugin is currently
+        installed, so an omitted --scope targets the existing installation
+        instead of blindly assuming the per-user scope; only the Anthropic
+        Claude Code CLI has a scope concept, so every other tool resolves to
+        "user"; the scopes are probed from the strongest ("local") down to
+        the weakest ("user"), and a scope counts as a match when its
+        settings file registers the plugin under "enabledPlugins" (the value
+        may be true or false, since even a disabled plugin is registered in
+        that scope)  */
+    private async detectScope (tool: Tool): Promise<Scope> {
+        if (tool !== "claude")
+            return "user"
+        const scopes: Scope[] = [ "local", "project", "user" ]
+        for (const scope of scopes) {
+            const file = this.statuslineSettingsFile(tool, scope)
+
+            /*  read and parse the settings file, skipping the scope on any
+                read or parse error (a missing or malformed file simply
+                cannot register the plugin)  */
+            let settings: unknown
+            try {
+                const text = await fs.readFile(file, "utf8")
+                settings = JSON.parse(text)
+            }
+            catch {
+                continue
+            }
+
+            /*  a match is the presence of the "ase@ase" key under
+                "enabledPlugins", regardless of its true/false value  */
+            const plugins = (settings as { enabledPlugins?: Record<string, unknown> })?.enabledPlugins
+            if (plugins !== undefined && plugins !== null
+                && Object.prototype.hasOwnProperty.call(plugins, "ase@ase")) {
+                if (scope !== "user")
+                    this.log.write("info", `setup: detected ASE plugin installation in scope "${scope}"`)
+                return scope
+            }
+        }
+        return "user"
+    }
+
     /*  register commands  */
     register (program: Command): void {
         /*  default for --dev derived from ASE_SETUP_DEV environment variable  */
@@ -966,11 +1007,13 @@ export default class SetupCommand {
             .command("update")
             .description("update the ASE tool and the ASE plugin for a tool")
             .option("-t, --tool <tool>",   "target tool (\"claude\", \"copilot\", or \"codex\")", toolDflt)
-            .option("-s, --scope <scope>", "target scope (\"user\", \"project\", or \"local\")", "user")
+            .option("-s, --scope <scope>", "target scope (\"user\", \"project\", or \"local\", default: auto-detected)")
             .option("-f, --force",         "always perform the update, even if already at latest version", false)
             .option("-d, --dev",           "use local working copy instead of remote/bundled repository", devDflt)
-            .action(async (opts: { tool: string, scope: string, force: boolean, dev: boolean }) => {
-                process.exit(await this.doUpdate(this.parseTool(opts.tool), opts.force, opts.dev, this.parseScope(opts.scope)))
+            .action(async (opts: { tool: string, scope: string | undefined, force: boolean, dev: boolean }) => {
+                const tool  = this.parseTool(opts.tool)
+                const scope = opts.scope === undefined ? await this.detectScope(tool) : this.parseScope(opts.scope)
+                process.exit(await this.doUpdate(tool, opts.force, opts.dev, scope))
             })
 
         /*  register CLI sub-command "ase setup uninstall"  */
@@ -978,10 +1021,12 @@ export default class SetupCommand {
             .command("uninstall")
             .description("uninstall the ASE plugin for a tool and the ASE tool")
             .option("-t, --tool <tool>",   "target tool (\"claude\", \"copilot\", or \"codex\")", toolDflt)
-            .option("-s, --scope <scope>", "target scope (\"user\", \"project\", or \"local\")", "user")
+            .option("-s, --scope <scope>", "target scope (\"user\", \"project\", or \"local\", default: auto-detected)")
             .option("-d, --dev",           "use local working copy instead of remote/bundled repository", devDflt)
-            .action(async (opts: { tool: string, scope: string, dev: boolean }) => {
-                process.exit(await this.doUninstall(this.parseTool(opts.tool), opts.dev, this.parseScope(opts.scope)))
+            .action(async (opts: { tool: string, scope: string | undefined, dev: boolean }) => {
+                const tool  = this.parseTool(opts.tool)
+                const scope = opts.scope === undefined ? await this.detectScope(tool) : this.parseScope(opts.scope)
+                process.exit(await this.doUninstall(tool, opts.dev, scope))
             })
 
         /*  register CLI sub-command "ase setup enable"  */
@@ -989,9 +1034,11 @@ export default class SetupCommand {
             .command("enable")
             .description("enable the ASE plugin for a tool")
             .option("-t, --tool <tool>",   "target tool (\"claude\", \"copilot\", or \"codex\")", toolDflt)
-            .option("-s, --scope <scope>", "target scope (\"user\", \"project\", or \"local\")", "user")
-            .action(async (opts: { tool: string, scope: string }) => {
-                process.exit(await this.doEnable(this.parseTool(opts.tool), this.parseScope(opts.scope)))
+            .option("-s, --scope <scope>", "target scope (\"user\", \"project\", or \"local\", default: auto-detected)")
+            .action(async (opts: { tool: string, scope: string | undefined }) => {
+                const tool  = this.parseTool(opts.tool)
+                const scope = opts.scope === undefined ? await this.detectScope(tool) : this.parseScope(opts.scope)
+                process.exit(await this.doEnable(tool, scope))
             })
 
         /*  register CLI sub-command "ase setup disable"  */
@@ -999,9 +1046,11 @@ export default class SetupCommand {
             .command("disable")
             .description("disable the ASE plugin for a tool")
             .option("-t, --tool <tool>",   "target tool (\"claude\", \"copilot\", or \"codex\")", toolDflt)
-            .option("-s, --scope <scope>", "target scope (\"user\", \"project\", or \"local\")", "user")
-            .action(async (opts: { tool: string, scope: string }) => {
-                process.exit(await this.doDisable(this.parseTool(opts.tool), this.parseScope(opts.scope)))
+            .option("-s, --scope <scope>", "target scope (\"user\", \"project\", or \"local\", default: auto-detected)")
+            .action(async (opts: { tool: string, scope: string | undefined }) => {
+                const tool  = this.parseTool(opts.tool)
+                const scope = opts.scope === undefined ? await this.detectScope(tool) : this.parseScope(opts.scope)
+                process.exit(await this.doDisable(tool, scope))
             })
 
         /*  register CLI sub-command "ase setup mcp"  */


### PR DESCRIPTION
## Symptom

With the ASE plugin installed only in the Claude Code **project** or **local** scope (e.g. `ase setup install --scope project`), running a plain `ase setup update` from within the project reports an error and exits non-zero — although the update itself effectively succeeds:

- `npm update -g @rse/ase` updates the ASE CLI tool just fine, but
- the subsequent `claude plugin update ase@ase` is executed **without** `--scope` (the hard-coded option default is `user`), and fails because the plugin is not registered in the per-user scope.

## Root cause

`tool/src/ase-setup.ts` registers `-s, --scope` with a hard-coded default of `"user"` for all `setup` sub-commands. For `update`, `uninstall`, `enable`, and `disable` this default is an assumption about where the plugin *is already installed* — and it is wrong whenever the installation lives in the `project` or `local` scope.

## Fix

- New private method `detectScope(tool)`: when `--scope` is omitted, probe the Claude Code settings files from the strongest to the weakest scope (`local` → `project` → `user`, resolved via the existing `statuslineSettingsFile()` helper) for a registered `enabledPlugins` entry `"ase@ase"` (its `true`/`false` value does not matter — even a disabled plugin is registered in that scope). The first match wins and is logged; no match falls back to `user`, i.e. the previous behavior.
- Wired into the `update`, `uninstall`, `enable`, and `disable` actions. An explicitly given `--scope` always wins. `install` keeps its `user` default (there is no existing installation to detect), `mcp`/`statusline` are untouched. For `--tool copilot|codex` detection immediately resolves to `user`, so `requireClaudeScope()` semantics are preserved.
- `docs/usage-tool.md` updated accordingly.

## Testing

- `npm start build` (lint + tsc + plugin copy) passes cleanly.
- Functional tests with `claude`/`npm` shims and a fake `$HOME`:
  - project-scope-only installation, `ase setup update --force` → `setup: detected ASE plugin installation in scope "project"`, runs `claude plugin update ase@ase --scope project`, exit 0;
  - explicit `--scope user` → no detection, no `--scope` argument (unchanged behavior);
  - no ASE registration anywhere → falls back to `user` (unchanged behavior);
  - `ase setup enable` with a `settings.local.json` registration (`"ase@ase": false`) → `claude plugin enable ase@ase --scope local`;
  - precedence with registrations in both `local` and `project` → `local` wins; a malformed settings file is skipped gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
